### PR TITLE
Update for EspressIf 2.x to 3.0

### DIFF
--- a/papracode-thruhole/papracode-thruhole.ino
+++ b/papracode-thruhole/papracode-thruhole.ino
@@ -1,3 +1,5 @@
+#include <dummy.h>
+
 /*
   papracode
     - Reads battery voltage and lights up LEDs to mimic M12 battery fuel gauge
@@ -137,8 +139,7 @@ void setup() {
   pinMode(analogPot, INPUT);
   pinMode(analogBatt, INPUT);
   pinMode(buzzerPin, OUTPUT);
-  ledcAttachPin(PWMPin, pwmChannel);
-  ledcSetup(pwmChannel, PWM_Freq, PWM_Res);
+  ledcAttach(PWMPin, PWM_Freq, PWM_Res);
 
   digitalWrite(led1, LOW);
   digitalWrite(led2, LOW);
@@ -191,7 +192,7 @@ void loop() {
   } else {
     fanPWM = maxPWM;
   }
-  ledcWrite(pwmChannel, fanPWM);
+  ledcWrite(PWMPin, fanPWM);
 
   uint32_t rawBatteryValue = analogRead(analogBatt);
   battery = ( ( battery * ( numBatterySamples - 1 ) ) + ( rawBatteryValue ) ) / numBatterySamples;


### PR DESCRIPTION
EspressIf 2.x to 3.0 had a breaking change for ledc this fixed PWM pin writes.

ledcSetup

ledcAttachPin

These functions were merged in the new version of the ledc library from espressif.  

Migration guide here for reference to fix changes:

https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html